### PR TITLE
chore(ci): rename sdk variable

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,12 +1,14 @@
 name: 'Start local Dash network'
-description: 'Invokes mn-bootstrap to set up a local network for CI'
+description: 'Invokes dashmate to set up a local network for CI'
 inputs:
   dashmate-branch:
     description: 'dashmate branch to use'
   dapi-branch:
-    description: 'dapi branch to be injected into mn-bootstrap'
+    description: 'dapi branch to be injected into dashmate'
   drive-branch:
+    description: 'drive branch to be injected into dashmate'
   sdk-branch:
+    description: 'Dash SDK (DashJS) branch to be injected into dashmate'
   actions-cache-url:
     description: ''
   actions-cache-token:

--- a/action.yml
+++ b/action.yml
@@ -6,9 +6,7 @@ inputs:
   dapi-branch:
     description: 'dapi branch to be injected into mn-bootstrap'
   drive-branch:
-    description: 'drive branch to be injected into mn-bootstrap'
-  install-sdk-version:
-    description: 'Dash SDK (DashJS) branch to be injected into mn-bootstrap'
+  sdk-branch:
   actions-cache-url:
     description: ''
   actions-cache-token:
@@ -34,4 +32,4 @@ runs:
           --dashmate-branch=${{ inputs.dashmate-branch }} \
           --dapi-branch=${{ inputs.dapi-branch }} \
           --drive-branch=${{ inputs.drive-branch }} \
-          --sdk-branch=${{ inputs.install-sdk-version }}
+          --sdk-branch=${{ inputs.sdk-branch }}


### PR DESCRIPTION
This PR

- renames `install-sdk-version` to `sdk-branch` for consistency with the rest of the workflow.
- renames `mn-bootstrap` to `dashmate`