### PR TITLE
chore(ci): pass variables in outputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,10 +14,24 @@ inputs:
   actions-cache-token:
     description: ''
 outputs:
-  test-output:
-    description: 'Should pass output here'
-    value: ${{ steps.start-local-network.outputs.fruit }}
-
+  current-version:
+    description: ''
+    value: ${{ steps.start-local-network.outputs.current-version }}
+  faucet-private-key:
+    description: ''
+    value: ${{ steps.start-local-network.outputs.faucet-private-key }}
+  dpns-top-level-identity-private-key:
+    description: ''
+    value: ${{ steps.start-local-network.outputs.dpns-top-level-identity-private-key }}
+  dpns-top-level-identity-id:
+    description: ''
+    value: ${{ steps.start-local-network.outputs.dpns-top-level-identity-id }}
+  dpns-contract-id:
+    description: ''
+    value: ${{ steps.start-local-network.outputs.dpns-contract-id }}
+  dpns-contract-block-height:
+    description: ''
+    value: ${{ steps.start-local-network.outputs.dpns-contract-block-height }}
 
 runs:
   using: composite
@@ -41,15 +55,3 @@ runs:
           --dapi-branch=${{ inputs.dapi-branch }} \
           --drive-branch=${{ inputs.drive-branch }} \
           --sdk-branch=${{ inputs.sdk-branch }}
-
-    - name: Test if output is set in shell var
-      shell: bash
-      run: |
-        echo 'In composite output test step'
-        echo $fruit
-
-    - name: Test if output is set in expression
-      shell: bash
-      run: |
-        echo 'In composite output expression test step'
-        echo ${{ steps.start-local-network.outputs.fruit }}

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: ''
   actions-cache-token:
     description: ''
+outputs:
+  test-output:
+    description: 'Should pass output here'
+
 
 runs:
   using: composite

--- a/action.yml
+++ b/action.yml
@@ -39,3 +39,8 @@ runs:
           --dapi-branch=${{ inputs.dapi-branch }} \
           --drive-branch=${{ inputs.drive-branch }} \
           --sdk-branch=${{ inputs.sdk-branch }}
+
+    - name: Test if output is set in composite
+      run: |
+        echo 'In composite output test step'
+        echo $test-output

--- a/action.yml
+++ b/action.yml
@@ -41,6 +41,7 @@ runs:
           --sdk-branch=${{ inputs.sdk-branch }}
 
     - name: Test if output is set in composite
+      shell: bash
       run: |
         echo 'In composite output test step'
         echo $test-output

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,7 @@ inputs:
 outputs:
   test-output:
     description: 'Should pass output here'
+    value: ${{ steps.start-local-network.outputs.fruit }}
 
 
 runs:
@@ -27,6 +28,7 @@ runs:
       run: npm ci && npm link
 
     - name: Start local network
+      id: start-local-network
       shell: bash
       working-directory: ${{ github.action_path }}
       env:
@@ -40,8 +42,14 @@ runs:
           --drive-branch=${{ inputs.drive-branch }} \
           --sdk-branch=${{ inputs.sdk-branch }}
 
-    - name: Test if output is set in composite
+    - name: Test if output is set in shell var
       shell: bash
       run: |
         echo 'In composite output test step'
-        echo $test-output
+        echo $fruit
+
+    - name: Test if output is set in expression
+      shell: bash
+      run: |
+        echo 'In composite output expression test step'
+        echo ${{ steps.start-local-network.outputs.fruit }}

--- a/bin/start-local-node.sh
+++ b/bin/start-local-node.sh
@@ -149,3 +149,4 @@ echo "dpns-top-level-identity-private-key=$DPNS_TOP_LEVEL_IDENTITY_PRIVATE_KEY" 
 echo "dpns-top-level-identity-id=$DPNS_TOP_LEVEL_IDENTITY_ID" >> $GITHUB_ENV
 echo "dpns-contract-id=$DPNS_CONTRACT_ID" >> $GITHUB_ENV
 echo "dpns-contract-block-height=$DPNS_CONTRACT_BLOCK_HEIGHT" >> $GITHUB_ENV
+echo "::set-output name=test-output::strawberry"

--- a/bin/start-local-node.sh
+++ b/bin/start-local-node.sh
@@ -143,10 +143,9 @@ dashmate group:start --verbose --wait-for-readiness
 
 # Export variables
 
-echo "current-version=$CURRENT_VERSION" >> $GITHUB_ENV
-echo "faucet-private-key=$FAUCET_PRIVATE_KEY" >> $GITHUB_ENV
-echo "dpns-top-level-identity-private-key=$DPNS_TOP_LEVEL_IDENTITY_PRIVATE_KEY" >> $GITHUB_ENV
-echo "dpns-top-level-identity-id=$DPNS_TOP_LEVEL_IDENTITY_ID" >> $GITHUB_ENV
-echo "dpns-contract-id=$DPNS_CONTRACT_ID" >> $GITHUB_ENV
-echo "dpns-contract-block-height=$DPNS_CONTRACT_BLOCK_HEIGHT" >> $GITHUB_ENV
-echo "::set-output name=fruit::strawberry"
+echo "::set-output name=current-version::$CURRENT_VERSION"
+echo "::set-output name=faucet-private-key::$FAUCET_PRIVATE_KEY"
+echo "::set-output name=dpns-top-level-identity-private-key::$DPNS_TOP_LEVEL_IDENTITY_PRIVATE_KEY"
+echo "::set-output name=dpns-top-level-identity-id::$DPNS_TOP_LEVEL_IDENTITY_ID"
+echo "::set-output name=dpns-contract-id::$DPNS_CONTRACT_ID"
+echo "::set-output name=dpns-contract-block-height::$DPNS_CONTRACT_BLOCK_HEIGHT"

--- a/bin/start-local-node.sh
+++ b/bin/start-local-node.sh
@@ -149,4 +149,4 @@ echo "dpns-top-level-identity-private-key=$DPNS_TOP_LEVEL_IDENTITY_PRIVATE_KEY" 
 echo "dpns-top-level-identity-id=$DPNS_TOP_LEVEL_IDENTITY_ID" >> $GITHUB_ENV
 echo "dpns-contract-id=$DPNS_CONTRACT_ID" >> $GITHUB_ENV
 echo "dpns-contract-block-height=$DPNS_CONTRACT_BLOCK_HEIGHT" >> $GITHUB_ENV
-echo "::set-output name=test-output::strawberry"
+echo "::set-output name=fruit::strawberry"


### PR DESCRIPTION
This PR modifies this action's behaviour from setting output vars using `$GITHUB_ENV` to using GitHub Actions outputs instead.