### PR TITLE
chore(ci): add logic to debug output settings in CI

### DIFF
--- a/bin/start-local-node.sh
+++ b/bin/start-local-node.sh
@@ -106,9 +106,8 @@ if [[ $DASHMATE_VERSION =~ ^0\.20* ]]; then
 else
   dashmate setup local --verbose --node-count="$NODE_COUNT" | tee setup.log
 fi
-#  Save npm cache
 
-mn config --config=local_1
+#  Save npm cache
 
 if [ -n "$drive_branch" ]
 then

--- a/bin/start-local-node.sh
+++ b/bin/start-local-node.sh
@@ -96,14 +96,13 @@ dashmate update
 echo "Setting up a local network"
 
 NODE_COUNT=3
-DEBUG_OUTPUT=true
 DASHMATE_VERSION=$(jq -r '.version' $GITHUB_WORKSPACE/package.json)
 
 dashmate config:set --config=local environment development
 dashmate config:set --config=local platform.drive.abci.log.stdout.level trace
 
 if [[ $DASHMATE_VERSION =~ ^0\.20* ]]; then
-  dashmate setup local --verbose --node-count="$NODE_COUNT" --debug-output="$DEBUG_OUTPUT" | tee setup.log
+  dashmate setup local --verbose --node-count="$NODE_COUNT" --debug | tee setup.log
 else
   dashmate setup local --verbose --node-count="$NODE_COUNT" | tee setup.log
 fi

--- a/bin/start-local-node.sh
+++ b/bin/start-local-node.sh
@@ -96,13 +96,20 @@ dashmate update
 echo "Setting up a local network"
 
 NODE_COUNT=3
+DEBUG_OUTPUT=true
+DASHMATE_VERSION=$(jq -r '.version' $GITHUB_WORKSPACE/package.json)
 
 dashmate config:set --config=local environment development
 dashmate config:set --config=local platform.drive.abci.log.stdout.level trace
 
-dashmate setup local --verbose --node-count="$NODE_COUNT" | tee setup.log
-
+if [[ $DASHMATE_VERSION =~ ^0\.20* ]]; then
+  dashmate setup local --verbose --node-count="$NODE_COUNT" --debug-output="$DEBUG_OUTPUT" | tee setup.log
+else
+  dashmate setup local --verbose --node-count="$NODE_COUNT" | tee setup.log
+fi
 #  Save npm cache
+
+mn config --config=local_1
 
 if [ -n "$drive_branch" ]
 then

--- a/bin/start-local-node.sh
+++ b/bin/start-local-node.sh
@@ -102,7 +102,7 @@ dashmate config:set --config=local environment development
 dashmate config:set --config=local platform.drive.abci.log.stdout.level trace
 
 if [[ $DASHMATE_VERSION =~ ^0\.20* ]]; then
-  dashmate setup local --verbose --node-count="$NODE_COUNT" --debug | tee setup.log
+  dashmate setup local --verbose --node-count="$NODE_COUNT" --debug-logs | tee setup.log
 else
   dashmate setup local --verbose --node-count="$NODE_COUNT" | tee setup.log
 fi


### PR DESCRIPTION
This PR

- queries the current dashmate version
- uses the `--debug-logs` flag to pass run with debug output if the package version starts with `0.20`