### PR TITLE
ci: remove update command

### DIFF
--- a/bin/start-local-node.sh
+++ b/bin/start-local-node.sh
@@ -76,10 +76,6 @@ then
   dashmate config:set --config=local platform.dapi.api.docker.build.path "$TMPDIR/dapi"
 fi
 
-# Update node software
-
-dashmate update
-
 # Setup local network
 
 echo "Setting up a local network"


### PR DESCRIPTION
This PR
- removes the `dashmate update` command, which is no longer required